### PR TITLE
Fix solc compiler config

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -1,6 +1,16 @@
 module.exports = {
   compilers: {
-    solc: '0.4.25'
+    solc: {
+      version: "0.4.25",    // Fetch exact version from solc-bin (default: truffle's version)
+      // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
+      // settings: {          // See the solidity docs for advice about optimization and evmVersion
+      //  optimizer: {
+      //    enabled: false,
+      //    runs: 200
+      //  },
+      //  evmVersion: "byzantium"
+      // }
+    }
   },  
   networks: {
     development: {


### PR DESCRIPTION
**Problem**
Current config makes `truffle compile|migrate` command to not working properly when using truffle 5.0.0.

**Solution**
This PR fix solc compiler config to make it work with truffle 5.0.0. 